### PR TITLE
incorporate LibRI and its dependecies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ string(REGEX MATCH " *VERSION *= *[0-9.]*" version ${mkfile})
 string(REGEX REPLACE " *VERSION *= *" "" version ${version})
 # Project information
 project(LibRPA VERSION ${version} LANGUAGES NONE)
+
+
+# options setup
+option(USE_LIBRI "Use LibRI for tensor contraction" OFF)
+
 # Add cmake load files
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(UseDoxygenDoc)
@@ -17,6 +22,24 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 if(EXISTS "${PROJECT_SOURCE_DIR}/cmake.inc")
   include("${PROJECT_SOURCE_DIR}/cmake.inc")
+endif()
+
+# use LibRI, which in turn depends on Cereal
+if(USE_LIBRI)
+  find_package(Cereal)
+  if(NOT Cereal_FOUND)
+    message(FATAL_ERROR "USE_LIBRI set, but no Cereal headers found as dependency")
+  endif()
+  find_package(LibComm)
+  if(NOT LibComm_FOUND)
+    message(FATAL_ERROR "USE_LIBRI set, but no LibComm headers found")
+  endif()
+  find_package(LibRI)
+  if(NOT LibRI_FOUND)
+    message(FATAL_ERROR "USE_LIBRI set, but no LibRI headers found")
+  endif()
+  add_compile_definitions("__USE_LIBRI")
+  message(STATUS "The project will be compiled with LibRI")
 endif()
 
 enable_language(CXX)

--- a/cmake.inc
+++ b/cmake.inc
@@ -4,6 +4,9 @@ set(CMAKE_CXX_COMPILER "mpiicpc" CACHE STRING "" FORCE)
 
 set(CMAKE_CXX_FLAGS "-g -O2 -qopenmp" CACHE STRING "" FORCE)
 
-set(LAPACK_LIBRARIES "-L$ENV{MKLROOT}/lib/intel64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core")
+# set(LAPACK_LIBRARIES "-L$ENV{MKLROOT}/lib/intel64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core")
+set(LAPACK_LIBRARIES "-L$ENV{MKLROOT}/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lmkl_blacs_intelmpi_lp64 -lpthread -lm -ldl")
 
-set(USE_LIBRARY OFF)
+set(USE_LIBRI OFF)
+
+set(BUILD_LIBRARY OFF)

--- a/cmake/FindCereal.cmake
+++ b/cmake/FindCereal.cmake
@@ -1,0 +1,42 @@
+# Find Cereal headers
+# Adapted from the ABACUS FindCereal module and cmake cookbook ch03-r10
+#
+# Variables
+#   CEREAL_INCLUDE_DIR - specify the path by either environment varaible or -DCEREAL_INCLUDE_DIR to search the cereal headers
+#
+#   Cereal_FOUND - True if cereal is found.
+#   Cereal_INCLUDE_DIR - Where to find cereal headers.
+
+# check environment variable if cmake definition is not set
+if(NOT CEREAL_INCLUDE_DIR)
+  set(CEREAL_INCLUDE_DIR $ENV{CEREAL_INCLUDE_DIR})
+endif()
+
+find_path(Cereal_INCLUDE_DIR
+  cereal/cereal.hpp
+  HINTS ${CEREAL_INCLUDE_DIR}
+)
+
+# Disable auto download. Handle CEREAL_FOUND instead
+# if(NOT Cereal_INCLUDE_DIR)
+#     include(FetchContent)
+#     FetchContent_Declare(
+#         cereal
+#         GIT_REPOSITORY https://github.com.cnpmjs.org/USCiLab/cereal.git
+#         # URL https://github.com/USCiLab/cereal/archive/refs/tags/v1.3.0.tar.gz
+#     )
+#     set(Cereal_INCLUDE_DIR ${cereal_SOURCE_DIR})
+# endif()
+
+# Handle the QUIET and REQUIRED arguments and
+# set Cereal_FOUND to TRUE if all variables are non-zero.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Cereal
+  FOUND_VAR
+    Cereal_FOUND
+  REQUIRED_VARS
+    Cereal_INCLUDE_DIR
+  )
+
+# Copy the results to the output variables and target.
+# mark_as_advanced(Cereal_INCLUDE_DIR)

--- a/cmake/FindLibComm.cmake
+++ b/cmake/FindLibComm.cmake
@@ -1,0 +1,25 @@
+# Find LibComm headers
+
+# Variables
+#   LIBCOMM_INCLUDE_DIR - specify the path by either environment varaible or -DLIBCOMM_INCLUDE_DIR to search the cereal headers
+#
+#   LibComm_FOUND - True if LibComm is found
+#   LibComm_INCLUDE_DIR - Where to find the LibComm headers
+
+# check environment variable if cmake definition is not set
+if(NOT LIBCOMM_INCLUDE_DIR)
+  set(LIBCOMM_INCLUDE_DIR $ENV{LIBCOMM_INCLUDE_DIR})
+endif()
+
+find_path(LibComm_INCLUDE_DIR
+  Comm/Comm_Tools.h
+  HINTS ${LIBCOMM_INCLUDE_DIR}
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibComm
+  FOUND_VAR
+    LibComm_FOUND
+  REQUIRED_VARS
+    LibComm_INCLUDE_DIR
+  )

--- a/cmake/FindLibRI.cmake
+++ b/cmake/FindLibRI.cmake
@@ -1,0 +1,25 @@
+# Find LibRI headers
+
+# Variables
+#   LIBRI_INCLUDE_DIR - specify the path by either environment varaible or -DLIBRI_INCLUDE_DIR to search the cereal headers
+#
+#   LibRI_FOUND - True if LibRI is found
+#   LibRI_INCLUDE_DIR - Where to find the LibRI headers
+
+# check environment variable if cmake definition is not set
+if(NOT LIBRI_INCLUDE_DIR)
+  set(LIBRI_INCLUDE_DIR $ENV{LIBRI_INCLUDE_DIR})
+endif()
+
+find_path(LibRI_INCLUDE_DIR
+  RI/ri/RI_Tools.h
+  HINTS ${LIBRI_INCLUDE_DIR}
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibRI
+  FOUND_VAR
+    LibRI_FOUND
+  REQUIRED_VARS
+    LibRI_INCLUDE_DIR
+  )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,15 @@ target_include_directories(librpa_exe
     ${CMAKE_CURRENT_LIST_DIR}
   )
 
+if(USE_LIBRI)
+  target_include_directories(librpa_exe
+    PUBLIC
+      ${Cereal_INCLUDE_DIR}
+      ${LibComm_INCLUDE_DIR}
+      ${LibRI_INCLUDE_DIR}
+    )
+endif()
+
 configure_file(envs.cpp.in envs.cpp)
 list(APPEND sources
         aperiodic_chi0.cpp
@@ -59,6 +68,14 @@ if(USE_LIBRARY)
     PUBLIC
       ${CMAKE_CURRENT_LIST_DIR}
     )
+  if(USE_LIBRI)
+    target_include_directories(librpa_lib
+      PUBLIC
+        ${Cereal_INCLUDE_DIR}
+        ${LibComm_INCLUDE_DIR}
+        ${LibRI_INCLUDE_DIR}
+      )
+  endif()
   target_sources(librpa_lib PUBLIC ${sources})
   target_link_libraries(librpa_lib PUBLIC ${LAPACK_LIBRARIES})
   target_link_libraries(librpa_exe PRIVATE librpa_lib)

--- a/src/blas_connector.h
+++ b/src/blas_connector.h
@@ -37,7 +37,7 @@ extern "C"
 		
 	// void dgemv_(const char *transa, const int *m, const int *n, const double *alpha,  const double *a,  
 	// 	const int *lda, const double *x, const int *incx, const double *beta, double *y, const int *incy);
-	double dgemv_(const char*const transA, const int*const m, const int*const n,
+	void dgemv_(const char*const transA, const int*const m, const int*const n,
 		const double*const alpha, const double*const A, const int*const ldA, const double*const X, const int*const incX,
 		const double*const beta, double*const Y, const int*const incY);
 

--- a/src/chi0.h
+++ b/src/chi0.h
@@ -111,3 +111,4 @@ map<size_t, matrix> compute_chi0_munu_tau_LRI_saveN_noreshape(const map<size_t, 
                                                               const vector<int> iRs,
                                                               atom_t mu, atom_t nu);
 
+extern bool use_libri_chi0;

--- a/src/complexmatrix.cpp
+++ b/src/complexmatrix.cpp
@@ -454,7 +454,7 @@ ComplexMatrix conj(const ComplexMatrix &m)
 	return cm;
 }
 
-ComplexMatrix power_hemat(ComplexMatrix &cmat, double power, bool original_filter, double threshold)
+ComplexMatrix power_hemat(ComplexMatrix &cmat, double power, bool filter_original, double threshold)
 {
     assert (cmat.nr == cmat.nc);
     const char jobz = 'V';
@@ -478,7 +478,7 @@ ComplexMatrix power_hemat(ComplexMatrix &cmat, double power, bool original_filte
         if (w[i] < threshold)
         {
             wpow[i] = 0;
-            if (original_filter)
+            if (filter_original)
                 w[i] = 0;
         }
         else
@@ -493,6 +493,7 @@ ComplexMatrix power_hemat(ComplexMatrix &cmat, double power, bool original_filte
 
     evconj = transpose(cmat, true);
     // recover the original matrix here
+    // NOTE: may need a ComplexMatrix object to back up the matrix when the original matrix is required to save a second matmul
     for ( int i = 0; i != cmat.nr; i++ )
         for ( int j = 0; j != cmat.nc; j++ )
             evconj.c[i*cmat.nc+j] *= w[i];

--- a/src/complexmatrix.h
+++ b/src/complexmatrix.h
@@ -112,10 +112,22 @@ void scaled_sum(
 		ComplexMatrix **m2, 
 		ComplexMatrix **mout);
 
-//! compute the power of Hermitian matrix. Hermicity not checked itself
-ComplexMatrix power_hemat(ComplexMatrix &cmat, double power, bool original_filter,
+//! compute the power of Hermitian matrix. Note that the hermicity not checked itself
+/*
+ * @param cmat: the complex matrix to compute power
+ * @param power: the power to compute
+ * @param filter_original: whether to filter the small values when recovering the original matrix
+ * @param threshold: eigenvalue threshold to filter out in computing the power matrix
+ */
+ComplexMatrix power_hemat(ComplexMatrix &cmat, double power, bool filter_original = false,
                           double threshold = -1e16); // Minye Zhang add 2022-06-04
+
 //! Does the same as power_hemat, but save the powered matrix in the original matrix
+/*
+ * @param cmat: the complex matrix to compute power
+ * @param power: the power to compute
+ * @param threshold: eigenvalue threshold to filter out in computing the power matrix
+ */
 void power_hemat_onsite(ComplexMatrix &cmat, double power, double threshold = -1e16); // Minye Zhang add 2022-07-07
 
 void print_complex_matrix(const char *desc, const ComplexMatrix &mat);

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1,11 +1,12 @@
-#include "input.h"
 /* #include "atoms.h" */
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <regex>
 #include "cal_periodic_chi0.h"
-#include "meanfield.h"
 #include "constants.h"
+#include "input.h"
+#include "meanfield.h"
 using namespace std;
 double cs_threshold = 1E-6;
 double vq_threshold = 1e-6;
@@ -157,6 +158,20 @@ void InputParser::parse_string(const std::string &vname, std::string &var, const
     std::string s = get_last_matched(params, vname, "([\\w ,;.]+)", 1);
     if (s != "")
         var = s;
+    else
+        flag = 1;
+    if (flag) var = de;
+}
+
+void InputParser::parse_bool(const std::string &vname, bool &var, const bool &de, int &flag)
+{
+    flag = 0;
+    std::string s = get_last_matched(params, vname, "([\\w]+)", 1);
+    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    if (s == "true" || s == "t" || s == ".t.")
+        var = true;
+    else if (s == "f" || s == "false" || s == ".f.")
+        var = false;
     else
         flag = 1;
     if (flag) var = de;

--- a/src/input.h
+++ b/src/input.h
@@ -63,6 +63,8 @@ class InputParser
         void parse_int(const std::string &vname, int &var, int de, int &flag);
         //! parse single string to var
         void parse_string(const std::string &vname, std::string &var, const std::string &de, int &flag);
+        //! parse single bool to var
+        void parse_bool(const std::string &vname, bool &var, const bool &de, int &flag);
 };
 
 //! Class to represent the input file

--- a/src/lib_main.cpp
+++ b/src/lib_main.cpp
@@ -28,6 +28,7 @@ int main(int argc, char **argv)
     parser.parse_double("cs_threshold", cs_threshold, 1e-6, flag);
     parser.parse_double("vq_threshold", vq_threshold, 1e-6, flag);
     parser.parse_double("sqrt_coulomb_threshold", sqrt_coulomb_threshold, 1e-4, flag);
+    parser.parse_bool("use_libri_chi0", use_libri_chi0, false, flag);
 
     para_mpi.set_blacs_parameters();
     

--- a/tests/test_complexmatrix.cpp
+++ b/tests/test_complexmatrix.cpp
@@ -7,7 +7,7 @@ void test_power_hemat()
     a(0, 0) = cmplx(1, 0);
     a(1, 1) = cmplx(-1, 0);
     print_complex_matrix("a", a);
-    auto b = power_hemat(a, 2);
+    auto b = power_hemat(a, 2, false);
     print_complex_matrix("sq_a", b);
     assert( fequal(b(0, 0), cmplx(1, 0)) &&
             fequal(b(1, 1), cmplx(1, 0))
@@ -20,7 +20,7 @@ void test_power_hemat()
     a(1, 0) = cmplx(0, 2);
     print_complex_matrix("a", a);
     auto origa = a;
-    b = power_hemat(a, 0.5);
+    b = power_hemat(a, 0.5, false);
     print_complex_matrix("sqrt_a", b);
     // phase is undetermined, use square of sqrt to check
     /* assert( fequal(b(0, 0), cmplx(1, 0)) && */


### PR DESCRIPTION
Add
* cmake option to use LibRI
* cmake modules to find LibRI and its deps (Cereal, LibRI, LibComm)
* compiler definition to control whether to compile with LibRI
* runtime option to use LibRI routing

Changes
* adapt `RPA` object to the newest version (220908)
* return type `double` to `void` for `dgemv` to conform with LibRI

Note: Compilation w/wo LibRI passed, but Correctness is not checked yet.