### PR TITLE
Add Cs_LRI struct to store triple coeff data in both original and LibRI-Tensor format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,12 @@ jobs:
           CXX=mpiicpc cmake -DUSE_LIBRI=ON -DUSE_GREENX_API=ON -B $BUILDDIR -DENABLE_TEST=ON
           cmake --build $BUILDDIR -j 2
           cmake --build $BUILDDIR --target test
+      - name: Build Fortran binding
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          export BUILDDIR="build_fortran_bind"
+          CXX=mpiicpc cmake -DUSE_LIBRI=OFF -DUSE_GREENX_API=OFF -DENABLE_FORTRAN_BIND=ON -B $BUILDDIR -DENABLE_TEST=OFF
+          cmake --build $BUILDDIR -j 2
       - name: Save last test log for check
         if: always()
         uses: actions/upload-artifact@v3

--- a/binding/fortran/CMakeLists.txt
+++ b/binding/fortran/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(rpa_f_lib
   PRIVATE
   librpa_f.f90
 )
+target_link_libraries(rpa_f_lib PRIVATE rpa_lib)
 
 install(TARGETS rpa_f_lib
         ARCHIVE

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -20,6 +20,14 @@ target_include_directories(rpa_exe
   )
 
 target_sources(rpa_exe PRIVATE ${exe_sources})
+if(USE_LIBRI)
+  target_include_directories(rpa_exe
+    PRIVATE
+      ${Cereal_INCLUDE_DIR}
+      ${LibComm_INCLUDE_DIR}
+      ${LibRI_INCLUDE_DIR}
+    )
+endif()
 
 target_link_libraries(rpa_exe PRIVATE rpa_lib ${math_libs} ${parallel_libs})
 

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -249,7 +249,7 @@ int main(int argc, char **argv)
     {
         if (mpi_comm_global_h.is_root()) lib_printf("Complete copy of Cs and V on each process\n");
         local_atpair = generate_atom_pair_from_nat(natom, false);
-        read_Cs("./", Params::cs_threshold,local_atpair);
+        read_Cs("./", Params::cs_threshold, local_atpair, Params::binary_input);
         read_Vq_full("./", "coulomb_mat", false);
     }
 

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -257,13 +257,23 @@ int main(int argc, char **argv)
     {
         if (i == mpi_comm_global_h.myid)
         {
-            lib_printf("| process %d: Cs size %d from local atpair size %zu\n",
-                    mpi_comm_global_h.myid, get_num_keys(Cs), local_atpair.size());
+            if (Cs_data.use_libri)
+            {
+                lib_printf("| process %d: Cs size %d from local atpair size %zu\n",
+                        mpi_comm_global_h.myid, get_num_keys(Cs_data.data_libri), local_atpair.size());
+                ofs_myid << "Cs size: " << get_num_keys(Cs_data.data_libri) << ", with keys:\n";
+                print_keys(ofs_myid, Cs_data.data_libri);
+            }
+            else
+            {
+                lib_printf("| process %d: Cs size %d from local atpair size %zu\n",
+                        mpi_comm_global_h.myid, get_num_keys(Cs_data.data_IJR), local_atpair.size());
+                ofs_myid << "Cs size: " << get_num_keys(Cs_data.data_IJR) << ", with keys:\n";
+                print_keys(ofs_myid, Cs_data.data_IJR);
+            }
         }
         mpi_comm_global_h.barrier();
     }
-    ofs_myid << "Cs size: " << get_num_keys(Cs) << ", with keys:\n";
-    print_keys(ofs_myid, Cs);
     std::flush(ofs_myid);
 
     // debug, check available Coulomb blocks on each process
@@ -321,7 +331,7 @@ int main(int argc, char **argv)
     if ( task != task_t::EXX )
     {
         Profiler::start("chi0_build", "Build response function chi0");
-        chi0.build(Cs, Rlist, period, local_atpair, qlist,
+        chi0.build(Cs_data, Rlist, period, local_atpair, qlist,
                    TFGrids::get_grid_type(Params::tfgrids_type), true);
         Profiler::stop("chi0_build");
     }
@@ -358,7 +368,7 @@ int main(int argc, char **argv)
     // Cs is not required after chi0 is computed in rpa task
     if (task == task_t::RPA)
     {
-        Cs.clear();
+        Cs_data.clear();
     }
 
     LIBRPA::utils::release_free_mem();
@@ -603,7 +613,7 @@ int main(int argc, char **argv)
 
         Profiler::start("g0w0_exx", "Build exchange self-energy");
         auto exx = LIBRPA::Exx(meanfield, kfrac_list);
-        exx.build_exx_orbital_energy(Cs, Rlist, period, VR);
+        exx.build_exx_orbital_energy(Cs_data, Rlist, period, VR);
         Profiler::stop("g0w0_exx");
         if (mpi_comm_global_h.is_root())
         {
@@ -656,7 +666,7 @@ int main(int argc, char **argv)
 
         LIBRPA::G0W0 s_g0w0(meanfield, kfrac_list, chi0.tfg);
         Profiler::start("g0w0_sigc_IJ", "Build correlation self-energy");
-        s_g0w0.build_spacetime_LibRI(Cs, Wc_freq_q, Rlist, period);
+        s_g0w0.build_spacetime_LibRI(Cs_data, Wc_freq_q, Rlist, period);
         Profiler::stop("g0w0_sigc_IJ");
 
         if (Params::debug)

--- a/driver/read_data.cpp
+++ b/driver/read_data.cpp
@@ -318,6 +318,7 @@ static size_t handle_Cs_file_binary(const string &file_path, double threshold, c
         cs_ptr->create(n_i * n_j, n_mu);
         infile.read((char *) cs_ptr->c, n_i * n_j * n_mu * sizeof(double));
         bool insert_index_only = loc_atp_index.count(ia1) && (*cs_ptr).absmax() >= threshold;
+        // cout << (*cs_ptr).absmax() << "\n";
         set_ao_basis_aux(ia1, ia2, n_i, n_j, n_mu, R, cs_ptr->c, int(insert_index_only));
         // cout<<cs_ptr->nr<<cs_ptr->nc<<endl;
         if (insert_index_only)

--- a/src/app_exx.cpp
+++ b/src/app_exx.cpp
@@ -61,7 +61,7 @@ std::vector<double> compute_exx_orbital_energy_(int i_state_low, int i_state_hig
     const auto VR = FT_Vq(Vq_cut, Rlist, true);
     // TODO: kfrac_list should depend on i_kpoints_compute
     auto exx = LIBRPA::Exx(meanfield, kfrac_list);
-    exx.build_exx_orbital_energy(Cs, Rlist, period, VR);
+    exx.build_exx_orbital_energy(Cs_data, Rlist, period, VR);
 
     for (int isp = 0; isp != meanfield.get_n_spins(); isp++)
     {

--- a/src/app_rpa.cpp
+++ b/src/app_rpa.cpp
@@ -42,10 +42,6 @@ void get_rpa_correlation_energy_(std::complex<double> &rpa_corr,
     }
 
     mpi_comm_global_h.barrier();
-    if (mpi_comm_global_h.myid == 0)
-    {
-        cout << "Initialization finished, start task job from myid\n";
-    }
 
     Profiler::start("chi0_build", "Build response function chi0");
     chi0.build(Cs_data, Rlist, period, local_atpair, qlist, TFGrids::get_grid_type(Params::tfgrids_type), true);

--- a/src/app_rpa.cpp
+++ b/src/app_rpa.cpp
@@ -48,7 +48,7 @@ void get_rpa_correlation_energy_(std::complex<double> &rpa_corr,
     }
 
     Profiler::start("chi0_build", "Build response function chi0");
-    chi0.build(Cs, Rlist, period, local_atpair, qlist, TFGrids::get_grid_type(Params::tfgrids_type), true);
+    chi0.build(Cs_data, Rlist, period, local_atpair, qlist, TFGrids::get_grid_type(Params::tfgrids_type), true);
     Profiler::stop("chi0_build");
 
     if (Params::debug)
@@ -76,7 +76,7 @@ void get_rpa_correlation_energy_(std::complex<double> &rpa_corr,
 
     // NOTE: Cs is cleaned up.
     // This means that the behavior will be undefined if this function is called again
-    Cs.clear();
+    Cs_data.clear();
     LIBRPA::utils::release_free_mem();
 
     mpi_comm_global_h.barrier();

--- a/src/chi0.h
+++ b/src/chi0.h
@@ -7,6 +7,7 @@
 #include <set>
 #include "meanfield.h"
 #include "timefreq.h"
+#include "atoms.h"
 #include "ri.h"
 #include "vector3_order.h"
 

--- a/src/chi0.h
+++ b/src/chi0.h
@@ -35,26 +35,26 @@ class Chi0
         /*
          @todo add threshold parameter. Maybe in the class level?
          */
-        void build_chi0_q_space_time( atpair_R_mat_t &LRI_Cs,
+        void build_chi0_q_space_time(const Cs_LRI &Cs,
                                      const Vector3_Order<int> &R_period,
                                      const vector<atpair_t> &atpairs_ABF,
                                      const vector<Vector3_Order<double>> &qlist);
-        void build_chi0_q_space_time_atom_pair_routing(const atpair_R_mat_t &LRI_Cs,
+        void build_chi0_q_space_time_atom_pair_routing(const Cs_LRI &Cs,
                                                        const Vector3_Order<int> &R_period,
                                                        const vector<atpair_t> &atpairs_ABF,
                                                        const vector<Vector3_Order<double>> &qlist);
-        void build_chi0_q_space_time_R_tau_routing(const atpair_R_mat_t &LRI_Cs,
+        void build_chi0_q_space_time_R_tau_routing(const Cs_LRI &Cs,
                                                    const Vector3_Order<int> &R_period,
                                                    const vector<atpair_t> &atpairs_ABF,
                                                    const vector<Vector3_Order<double>> &qlist);
-        void build_chi0_q_space_time_LibRI_routing( atpair_R_mat_t &LRI_Cs,
+        void build_chi0_q_space_time_LibRI_routing(const Cs_LRI &Cs,
                                                    const Vector3_Order<int> &R_period,
                                                    const vector<atpair_t> &atpairs_ABF,
                                                    const vector<Vector3_Order<double>> &qlist);
 
         //! Internal procedure to compute chi0_q in the conventional method, i.e. in frequency domain and reciprocal space
         // TODO: implement the conventional method
-        void build_chi0_q_conventional(const atpair_R_mat_t &LRI_Cs,
+        void build_chi0_q_conventional(const Cs_LRI &Cs,
                                        const Vector3_Order<int> &R_period,
                                        const vector<atpair_t> &atpairs_ABF,
                                        const vector<Vector3_Order<double>> &qlist);
@@ -62,10 +62,10 @@ class Chi0
          * s_alpha and s_beta are the spin component of unoccupied Green's function, G_{alpha, beta}(tau)
          * correspondingly, occupied GF G_{beta, alpha}(-tau) will be used. itau must be positive.
          */
-        matrix compute_chi0_s_munu_tau_R(const atpair_R_mat_t &LRI_Cs,
-                                          const Vector3_Order<int> &R_period, 
-                                          int spin_channel,
-                                          atom_t mu, atom_t nu, double tau, Vector3_Order<int> R);
+        matrix compute_chi0_s_munu_tau_R(const atpair_R_mat_t &Cs_IJR,
+                                         const Vector3_Order<int> &R_period, 
+                                         int spin_channel,
+                                         atom_t mu, atom_t nu, double tau, Vector3_Order<int> R);
         // copy some reshape method inside chi0, test performance
         /* matrix reshape_Cs(const size_t n1, const size_t n2, const size_t n3, const std::shared_ptr<matrix> &Cs); */
         /* matrix reshape_dim_Cs(const size_t n1, const size_t n2, const size_t n3, const std::shared_ptr<matrix> &Cs);//(n1*n2,n3) -> (n1,n2*n3) */
@@ -82,7 +82,7 @@ class Chi0
             mf(mf_in), klist(klist_in), tfg(n_tf_grids) { gf_R_threshold = 1e-9; }
         ~Chi0() {};
         //! Build the independent response function in q-omega domain for ABFs on the atom pairs atpair_ABF and q-vectors in qlist
-        void build( atpair_R_mat_t &LRI_Cs,
+        void build(const Cs_LRI &Cs,
                    const vector<Vector3_Order<int>> &Rlist,
                    const Vector3_Order<int> &R_period,
                    const vector<atpair_t> &atpair_ABF,

--- a/src/envs_mpi.h
+++ b/src/envs_mpi.h
@@ -13,6 +13,7 @@
 //! @namespace LIBRPA           Global namespace for LibRPA functions and classes
 //! @namespace LIBRPA::envs     Facilities regarding computation envrionment
 //! @namespace LIBRPA::utils    Utilities functions
+//! @namespace LIBRPA::app      Functions for applications, e.g. RPA correlation, exact-exchange matrix
 
 namespace LIBRPA
 {

--- a/src/epsilon.cpp
+++ b/src/epsilon.cpp
@@ -19,8 +19,8 @@
 #include "parallel_mpi.h"
 #include "params.h"
 #include "pbc.h"
+#include "atoms.h"
 #include "profiler.h"
-#include "ri.h"
 #include "scalapack_connector.h"
 #include <omp.h>
 #if defined(__MACH__)

--- a/src/exx.h
+++ b/src/exx.h
@@ -24,7 +24,7 @@ class Exx
         void warn_dmat_IJR_nonzero_imag(const ComplexMatrix& dmat_cplx,
                                         const int& ispin, const atom_t& I, const atom_t& J,
                                         const Vector3_Order<int> R);
-        void build_exx_orbital_energy_LibRI(const atpair_R_mat_t& LRI_Cs,
+        void build_exx_orbital_energy_LibRI(const Cs_LRI &Cs,
                                             const vector<Vector3_Order<int>> &Rlist,
                                             const Vector3_Order<int> &R_period,
                                             const atpair_R_mat_t& coul_mat);
@@ -42,7 +42,7 @@ class Exx
 
         Exx(const MeanField& mf, const vector<Vector3_Order<double>> &kfrac_list): mf_(mf), kfrac_list_(kfrac_list) {};
         //! Build and store the density matrix from the meanfield object
-        void build_exx_orbital_energy(const atpair_R_mat_t& LRI_Cs,
+        void build_exx_orbital_energy(const Cs_LRI &Cs,
                                       const vector<Vector3_Order<int>> &Rlist,
                                       const Vector3_Order<int> &R_period,
                                       const atpair_R_mat_t& coul_mat);

--- a/src/gw.cpp
+++ b/src/gw.cpp
@@ -114,7 +114,7 @@ void G0W0::build_spacetime_LibRI(
                         {
                             const auto &R = R_Wc.first;
                             // handle the <IJ(R)> block
-                            Wc_libri[I][{J, {R.x, R.y, R.z}}] = RI::Tensor<double>({nabf_I, nabf_J}, R_Wc.second.get_real().sptr());
+                            Wc_libri[static_cast<int>(I)][{static_cast<int>(J), {R.x, R.y, R.z}}] = RI::Tensor<double>({nabf_I, nabf_J}, R_Wc.second.get_real().sptr());
                             // cout << "I " << I << " J " << J <<  " R " << R << " tau " << tau << endl ;
                             // cout << Wc_libri[I][{J, {R.x, R.y, R.z}}] << endl;
                             // handle the <JI(R)> block
@@ -124,7 +124,7 @@ void G0W0::build_spacetime_LibRI(
                             const auto Wc_IJmR = J_RWc.second.at(minusR).get_real().get_transpose();
                             // cout << R_Wc.second << endl;
                             // cout << Wc_IJmR << endl;
-                            Wc_libri[J][{I, {R.x, R.y, R.z}}] = RI::Tensor<double>({nabf_J, nabf_I}, Wc_IJmR.sptr());
+                            Wc_libri[static_cast<int>(J)][{static_cast<int>(I), {R.x, R.y, R.z}}] = RI::Tensor<double>({nabf_J, nabf_I}, Wc_IJmR.sptr());
                         }
                     }
                 }
@@ -164,7 +164,7 @@ void G0W0::build_spacetime_LibRI(
                                                               atomic_basis_wfc.get_global_index(J, j));
                             }
                         std::shared_ptr<std::valarray<double>> mat_ptr = std::make_shared<std::valarray<double>>(gf_IJ_block.c, gf_IJ_block.size);
-                        gf_libri[I][{J, {R.x, R.y, R.z}}] = RI::Tensor<double>({n_I, n_J}, mat_ptr);
+                        gf_libri[static_cast<int>(I)][{static_cast<int>(J), {R.x, R.y, R.z}}] = RI::Tensor<double>({n_I, n_J}, mat_ptr);
                     }
                 }
                 size_t n_obj_gf_libri = 0;

--- a/src/gw.h
+++ b/src/gw.h
@@ -46,7 +46,7 @@ public:
 
     //! using LibRI
     void build_spacetime_LibRI(
-        const atpair_R_mat_t &LRI_Cs,
+        const Cs_LRI &LRI_Cs,
         const map<double, atom_mapping<std::map<Vector3_Order<double>,
                                                 matrix_m<complex<double>>>>::pair_t_old> &Wc_freq_q,
         const vector<Vector3_Order<int>> &Rlist,

--- a/src/libri_stub.h
+++ b/src/libri_stub.h
@@ -1,0 +1,31 @@
+/*
+ * @file      libri_stub.h
+ * @brief     Stubbing classes and functions for LibRI
+ * @author    Min-Ye Zhang
+ * @date      2024-07-08
+ */
+#pragma once
+#ifndef LIBRPA_USE_LIBRI
+#include <vector>
+#include <memory>
+#include <valarray>
+#include <stdexcept>
+
+namespace RI
+{
+
+template <typename Tdata>
+class Tensor
+{
+public:
+    Tensor()
+    { throw std::logic_error("stub Tensor constructor is called"); };
+
+    Tensor(const std::vector<int> &dimension, std::shared_ptr<std::valarray<Tdata>> data_in)
+    { throw std::logic_error("stub Tensor constructor is called"); };
+
+    void clear() {};
+};
+
+} /* end of namespace RI */
+#endif

--- a/src/libri_stub.h
+++ b/src/libri_stub.h
@@ -24,6 +24,9 @@ public:
     Tensor(const std::vector<int> &dimension, std::shared_ptr<std::valarray<Tdata>> data_in)
     { throw std::logic_error("stub Tensor constructor is called"); };
 
+    Tensor(const std::initializer_list<std::size_t> &dimension, std::shared_ptr<std::valarray<Tdata>> data_in)
+    { throw std::logic_error("stub Tensor constructor is called"); };
+
     void clear() {};
 };
 

--- a/src/libri_utils.h
+++ b/src/libri_utils.h
@@ -7,6 +7,8 @@
 #include "vector3_order.h"
 #ifdef LIBRPA_USE_LIBRI
 #include <RI/global/Tensor.h>
+#else
+#include "libri_stub.h"
 #endif
 
 template <typename TA, typename Tcell>

--- a/src/librpa.cpp
+++ b/src/librpa.cpp
@@ -220,7 +220,13 @@ void set_ao_basis_aux(int I, int J, int nbasis_i, int nbasis_j, int naux_mu, int
     int cs_size = nbasis_i * nbasis_j * naux_mu;
     //(*cs_ptr).c=Cs_in;
 
-    Cs_data.use_libri = LIBRPA::parallel_routing == LIBRPA::ParallelRouting::LIBRI;
+    /*
+     * LIBRPA::parallel_routing may not be properly set when parsing to set_ao_basis_aux.
+     * Therefore using Params::parallel_routing string to check, because
+     * Params are required to set up after the environment initialization and before data transfer.
+     * */
+    // Cs_data.use_libri = LIBRPA::parallel_routing == LIBRPA::ParallelRouting::LIBRI;
+    Cs_data.use_libri = Params::parallel_routing == "libri";
 
     if (Cs_data.use_libri)
     {

--- a/src/librpa_main.cpp
+++ b/src/librpa_main.cpp
@@ -188,7 +188,7 @@ void librpa_main()
             local_atpair.push_back(iap);
         LIBRPA::utils::lib_printf("| process %d , local_atom_pair size:  %zu\n", mpi_comm_global_h.myid, local_atpair.size());
 
-        LIBRPA::utils::lib_printf("| process %d, size of Cs from local_atpair: %lu\n", mpi_comm_global_h.myid, Cs.size());
+        LIBRPA::utils::lib_printf("| process %d, size of Cs from local_atpair: %lu\n", mpi_comm_global_h.myid, Cs_data.data_IJR.size());
         // for(auto &ap:local_atpair)
         //     LIBRPA::utils::lib_printf("   |process %d , local_atom_pair:  %d,  %d\n", mpi_comm_global_h.myid,ap.first,ap.second);
     }
@@ -253,7 +253,7 @@ void librpa_main()
     if ( Params::task != "exx" )
     {
         Profiler::start("chi0_build", "Build response function chi0");
-        chi0.build(Cs, Rlist, period, local_atpair, qlist,
+        chi0.build(Cs_data, Rlist, period, local_atpair, qlist,
                    TFGrids::get_grid_type(Params::tfgrids_type), true);
         Profiler::stop("chi0_build");
     }
@@ -292,7 +292,7 @@ void librpa_main()
         // {
         //     Cs.erase(Cp.first);
         // }
-        Cs.clear();
+        Cs_data.clear();
         LIBRPA::utils::lib_printf("Cs have been cleaned!\n");
     }
 

--- a/src/matrix_m_parallel_utils.h
+++ b/src/matrix_m_parallel_utils.h
@@ -277,7 +277,7 @@ void map_block_to_IJ_storage(map<int, map<int, matrix_m<T>>> &IJmap,
             atbasis_row.get_local_index(i_glo, I, iI);
             atbasis_col.get_local_index(j_glo, J, jJ);
             if (IJmap.count(I) == 0 || IJmap.at(I).count(J) == 0 || IJmap.at(I).at(J).size() == 0)
-                IJmap[I][J] = matrix_m<T>{atbasis_row.get_atom_nb(I), atbasis_col.get_atom_nb(J), major_map};
+                IJmap[I][J] = matrix_m<T>{static_cast<int>(atbasis_row.get_atom_nb(I)), static_cast<int>(atbasis_col.get_atom_nb(J)), major_map};
             IJmap[I][J](iI, jJ) = mat_lo(i_lo, j_lo);
         }
 }

--- a/src/ri.cpp
+++ b/src/ri.cpp
@@ -23,7 +23,14 @@ vector<atpair_t> tot_atpair;
 vector<atpair_t> local_atpair;
 vector<atpair_t> tot_atpair_ordered;
 
-atpair_R_mat_t Cs;
+void Cs_LRI::clear()
+{
+    this->data_IJR.clear();
+    this->data_libri.clear();
+}
+
+Cs_LRI Cs_data;
+
 atpair_k_cplx_mat_t Vq;
 atpair_k_cplx_mat_t Vq_cut;
 map<Vector3_Order<double>, ComplexMatrix> Vq_block_loc;
@@ -165,6 +172,13 @@ void allreduce_atp_aux()
 {
     using LIBRPA::envs::mpi_comm_global;
     using LIBRPA::envs::mpi_comm_global_h;
+
+    if (Cs_data.use_libri)
+    {
+        return;
+    }
+
+    auto & Cs= Cs_data.data_IJR;
 
     for(int I=0;I!=natom;I++)
         for(int J=0;J!=natom;J++)

--- a/src/ri.h
+++ b/src/ri.h
@@ -11,7 +11,13 @@
 #include "vector3_order.h"
 #include "atoms.h"
 #include "complexmatrix.h"
-using std::map;
+
+#ifdef LIBRPA_USE_LIBRI
+#include <RI/global/Tensor.h>
+#else
+#include "libri_stub.h"
+#endif
+#include "libri_utils.h"
 
 extern int n_irk_points;
 extern int natom;
@@ -36,8 +42,20 @@ typedef atom_mapping< map<Vector3_Order<int>, std::shared_ptr<ComplexMatrix>> >:
 //! type alias of atom-pair mapping to complex matrix indexed by reciprocal vector
 typedef atom_mapping< map<Vector3_Order<double>, std::shared_ptr<ComplexMatrix>> >::pair_t_old atpair_k_cplx_mat_t;
 
-//! Tri-coefficient of localized RI (LRI) in real space. ABF on the first atom of the atom pair
-extern atpair_R_mat_t Cs;
+struct Cs_LRI
+{
+public:
+    bool use_libri;
+    // Tri-coefficient of localized RI (LRI) in real space. ABF on the first atom of the atom pair
+    atpair_R_mat_t data_IJR;
+    // Tri-coefficient of localized RI (LRI) in real space, represented using LibRI tensor class
+    std::map<int, std::map<libri_types<int, int>::TAC, RI::Tensor<double>>> data_libri;
+
+    void clear();
+};
+
+extern Cs_LRI Cs_data;
+
 //! Coulomb matrix in ABF, represented in the reciprocal space.
 extern atpair_k_cplx_mat_t Vq;
 //! Truncated Coulomb matrix in ABF, represented in the reciprocal space.


### PR DESCRIPTION
This avoids multiple creation of `Cs_libri` objects and reduces memory consumption.